### PR TITLE
Move delete task action to column components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "2025-12-29-refactor",
+    "name": "2025-12-30-delete-task",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/resources/views/components/columns/⚡closed.blade.php
+++ b/resources/views/components/columns/⚡closed.blade.php
@@ -15,6 +15,7 @@ new class extends Component
 
     #[On('task.moved')]
     #[On('task.updated')]
+    #[On('task-deleted')]
     public function refreshTasks()
     {
         unset($this->tasks);
@@ -57,6 +58,17 @@ new class extends Component
 
         $this->dispatch('task.moved');
     }
+
+    public function deleteTask($taskId)
+    {
+        $task = $this->project->tasks()->findOrFail($taskId);
+
+        $this->authorize('delete', $task->project);
+
+        $task->delete();
+
+        $this->dispatch('task-deleted', taskId: $task->id);
+    }
 };
 ?>
 
@@ -77,6 +89,30 @@ new class extends Component
                             class="w-full max-w-[95vw] lg:max-w-216"
                         >
                             <livewire:task :task="$task" lazy />
+                        </flux:modal>
+
+                        <flux:modal :name="'delete-task-' . $task->id" class="min-w-[22rem]">
+                            <div class="space-y-6">
+                                <div>
+                                    <flux:heading size="lg">Delete task?</flux:heading>
+                                    <flux:text class="mt-2">
+                                        You're about to delete this task. This action cannot be reversed.
+                                    </flux:text>
+                                </div>
+                                <div class="flex gap-2">
+                                    <flux:spacer />
+                                    <flux:modal.close>
+                                        <flux:button variant="ghost">Cancel</flux:button>
+                                    </flux:modal.close>
+                                    <flux:button
+                                        type="submit"
+                                        variant="danger"
+                                        wire:click="deleteTask({{ $task->id }})"
+                                    >
+                                        Delete task
+                                    </flux:button>
+                                </div>
+                            </div>
                         </flux:modal>
                     </div>
                 @empty

--- a/resources/views/components/columns/⚡closed.test.php
+++ b/resources/views/components/columns/⚡closed.test.php
@@ -1,5 +1,8 @@
 <?php
 
+use App\Models\ChecklistItem;
+use App\Models\Comment;
+use App\Models\Task;
 use App\Models\Team;
 use App\Models\User;
 use Livewire\Livewire;
@@ -73,4 +76,64 @@ it('reopens a closed task when moved to pending', function () {
     expect($task->closed_at)->toBeNull();
     expect($task->closed_by)->toBeNull();
     expect($task->completed_at)->toBeNull();
+});
+
+it('deletes task and all related resources successfully', function () {
+    $user = User::factory()->has(Team::factory())->create();
+    $team = $user->teams()->first();
+    $project = $team->projects()->create(['name' => 'Test Project', 'handle' => 'test-project']);
+    $task = $project->tasks()->create([
+        'title' => 'Test Task',
+        'user_id' => $user->id,
+        'team_id' => $team->id,
+        'number' => 1,
+        'closed_at' => now(),
+        'closed_by' => $user->id,
+    ]);
+
+    $comment = $task->comments()->create([
+        'user_id' => $user->id,
+        'content' => 'Test comment',
+    ]);
+
+    $checklistItem = $task->checklistItems()->create([
+        'content' => 'Test checklist item',
+        'completed' => false,
+    ]);
+
+    $tag = $team->tags()->create(['name' => 'Bug Fix']);
+    $task->tags()->attach($tag->id);
+
+    expect($task->comments)->toHaveCount(1);
+    expect($task->checklistItems)->toHaveCount(1);
+    expect($task->tags)->toHaveCount(1);
+
+    Livewire::actingAs($user)->test('columns.closed', ['project' => $project])
+        ->call('deleteTask', $task->id)
+        ->assertDispatched('task-deleted', taskId: $task->id);
+
+    expect(Task::find($task->id))->toBeNull();
+    expect(Comment::find($comment->id))->toBeNull();
+    expect(ChecklistItem::find($checklistItem->id))->toBeNull();
+    expect($tag->fresh())->not->toBeNull();
+});
+
+it('prevents non-authorized users from deleting tasks', function () {
+    $user1 = User::factory()->has(Team::factory())->create();
+    $team1 = $user1->teams()->first();
+    $project = $team1->projects()->create(['name' => 'Test Project', 'handle' => 'test-project']);
+    $task = $project->tasks()->create([
+        'title' => 'Test Task',
+        'user_id' => $user1->id,
+        'team_id' => $team1->id,
+        'number' => 1,
+    ]);
+
+    $user2 = User::factory()->create();
+
+    Livewire::actingAs($user2)->test('columns.closed', ['project' => $project])
+        ->call('deleteTask', $task->id)
+        ->assertForbidden();
+
+    expect(Task::find($task->id))->not->toBeNull();
 });

--- a/resources/views/components/columns/⚡completed.blade.php
+++ b/resources/views/components/columns/⚡completed.blade.php
@@ -15,6 +15,7 @@ new class extends Component
 
     #[On('task.moved')]
     #[On('task.updated')]
+    #[On('task-deleted')]
     public function refreshTasks()
     {
         unset($this->tasks);
@@ -57,6 +58,17 @@ new class extends Component
 
         $this->dispatch('task.moved');
     }
+
+    public function deleteTask($taskId)
+    {
+        $task = $this->project->tasks()->findOrFail($taskId);
+
+        $this->authorize('delete', $task->project);
+
+        $task->delete();
+
+        $this->dispatch('task-deleted', taskId: $task->id);
+    }
 };
 ?>
 
@@ -77,6 +89,30 @@ new class extends Component
                             class="w-full max-w-[95vw] lg:max-w-216"
                         >
                             <livewire:task :task="$task" lazy />
+                        </flux:modal>
+
+                        <flux:modal :name="'delete-task-' . $task->id" class="min-w-[22rem]">
+                            <div class="space-y-6">
+                                <div>
+                                    <flux:heading size="lg">Delete task?</flux:heading>
+                                    <flux:text class="mt-2">
+                                        You're about to delete this task. This action cannot be reversed.
+                                    </flux:text>
+                                </div>
+                                <div class="flex gap-2">
+                                    <flux:spacer />
+                                    <flux:modal.close>
+                                        <flux:button variant="ghost">Cancel</flux:button>
+                                    </flux:modal.close>
+                                    <flux:button
+                                        type="submit"
+                                        variant="danger"
+                                        wire:click="deleteTask({{ $task->id }})"
+                                    >
+                                        Delete task
+                                    </flux:button>
+                                </div>
+                            </div>
                         </flux:modal>
                     </div>
                 @empty

--- a/resources/views/components/columns/⚡completed.test.php
+++ b/resources/views/components/columns/⚡completed.test.php
@@ -1,5 +1,8 @@
 <?php
 
+use App\Models\ChecklistItem;
+use App\Models\Comment;
+use App\Models\Task;
 use App\Models\Team;
 use App\Models\User;
 use Illuminate\Support\Facades\Notification;
@@ -52,4 +55,64 @@ it('notifies subscribers when task is completed', function () {
         \App\Notifications\TaskCompleted::class
     );
     Notification::assertNotSentTo($user, \App\Notifications\TaskCompleted::class);
+});
+
+it('deletes task and all related resources successfully', function () {
+    $user = User::factory()->has(Team::factory())->create();
+    $team = $user->teams()->first();
+    $project = $team->projects()->create(['name' => 'Test Project', 'handle' => 'test-project']);
+    $task = $project->tasks()->create([
+        'title' => 'Test Task',
+        'user_id' => $user->id,
+        'team_id' => $team->id,
+        'number' => 1,
+        'completed_at' => now(),
+        'completed_by' => $user->id,
+    ]);
+
+    $comment = $task->comments()->create([
+        'user_id' => $user->id,
+        'content' => 'Test comment',
+    ]);
+
+    $checklistItem = $task->checklistItems()->create([
+        'content' => 'Test checklist item',
+        'completed' => false,
+    ]);
+
+    $tag = $team->tags()->create(['name' => 'Bug Fix']);
+    $task->tags()->attach($tag->id);
+
+    expect($task->comments)->toHaveCount(1);
+    expect($task->checklistItems)->toHaveCount(1);
+    expect($task->tags)->toHaveCount(1);
+
+    Livewire::actingAs($user)->test('columns.completed', ['project' => $project])
+        ->call('deleteTask', $task->id)
+        ->assertDispatched('task-deleted', taskId: $task->id);
+
+    expect(Task::find($task->id))->toBeNull();
+    expect(Comment::find($comment->id))->toBeNull();
+    expect(ChecklistItem::find($checklistItem->id))->toBeNull();
+    expect($tag->fresh())->not->toBeNull();
+});
+
+it('prevents non-authorized users from deleting tasks', function () {
+    $user1 = User::factory()->has(Team::factory())->create();
+    $team1 = $user1->teams()->first();
+    $project = $team1->projects()->create(['name' => 'Test Project', 'handle' => 'test-project']);
+    $task = $project->tasks()->create([
+        'title' => 'Test Task',
+        'user_id' => $user1->id,
+        'team_id' => $team1->id,
+        'number' => 1,
+    ]);
+
+    $user2 = User::factory()->create();
+
+    Livewire::actingAs($user2)->test('columns.completed', ['project' => $project])
+        ->call('deleteTask', $task->id)
+        ->assertForbidden();
+
+    expect(Task::find($task->id))->not->toBeNull();
 });

--- a/resources/views/components/columns/⚡pending.blade.php
+++ b/resources/views/components/columns/⚡pending.blade.php
@@ -20,6 +20,7 @@ new class extends Component
     #[On('task.moved')]
     #[On('task.updated')]
     #[On('section.deleted')]
+    #[On('task-deleted')]
     public function refreshTasks()
     {
         unset($this->tasks);
@@ -71,6 +72,17 @@ new class extends Component
 
         $this->dispatch('task.moved');
     }
+
+    public function deleteTask($taskId)
+    {
+        $task = $this->project->tasks()->findOrFail($taskId);
+
+        $this->authorize('delete', $task->project);
+
+        $task->delete();
+
+        $this->dispatch('task-deleted', taskId: $task->id);
+    }
 };
 ?>
 
@@ -115,6 +127,30 @@ new class extends Component
                             class="w-full max-w-[95vw] lg:max-w-216"
                         >
                             <livewire:task :task="$task" lazy />
+                        </flux:modal>
+
+                        <flux:modal :name="'delete-task-' . $task->id" class="min-w-[22rem]">
+                            <div class="space-y-6">
+                                <div>
+                                    <flux:heading size="lg">Delete task?</flux:heading>
+                                    <flux:text class="mt-2">
+                                        You're about to delete this task. This action cannot be reversed.
+                                    </flux:text>
+                                </div>
+                                <div class="flex gap-2">
+                                    <flux:spacer />
+                                    <flux:modal.close>
+                                        <flux:button variant="ghost">Cancel</flux:button>
+                                    </flux:modal.close>
+                                    <flux:button
+                                        type="submit"
+                                        variant="danger"
+                                        wire:click="deleteTask({{ $task->id }})"
+                                    >
+                                        Delete task
+                                    </flux:button>
+                                </div>
+                            </div>
                         </flux:modal>
                     </div>
                 @endforeach

--- a/resources/views/components/columns/⚡pending.test.php
+++ b/resources/views/components/columns/⚡pending.test.php
@@ -1,5 +1,8 @@
 <?php
 
+use App\Models\ChecklistItem;
+use App\Models\Comment;
+use App\Models\Task;
 use App\Models\Team;
 use App\Models\User;
 use Livewire\Livewire;
@@ -100,4 +103,62 @@ it('removes section assignment and reopens completed task when moved to pending'
     expect($task->completed_by)->toBeNull();
     expect($task->reopened_at)->not->toBeNull();
     expect($task->reopened_by)->toEqual($user->id);
+});
+
+it('deletes task and all related resources successfully', function () {
+    $user = User::factory()->has(Team::factory())->create();
+    $team = $user->teams()->first();
+    $project = $team->projects()->create(['name' => 'Test Project', 'handle' => 'test-project']);
+    $task = $project->tasks()->create([
+        'title' => 'Test Task',
+        'user_id' => $user->id,
+        'team_id' => $team->id,
+        'number' => 1,
+    ]);
+
+    $comment = $task->comments()->create([
+        'user_id' => $user->id,
+        'content' => 'Test comment',
+    ]);
+
+    $checklistItem = $task->checklistItems()->create([
+        'content' => 'Test checklist item',
+        'completed' => false,
+    ]);
+
+    $tag = $team->tags()->create(['name' => 'Bug Fix']);
+    $task->tags()->attach($tag->id);
+
+    expect($task->comments)->toHaveCount(1);
+    expect($task->checklistItems)->toHaveCount(1);
+    expect($task->tags)->toHaveCount(1);
+
+    Livewire::actingAs($user)->test('columns.pending', ['project' => $project])
+        ->call('deleteTask', $task->id)
+        ->assertDispatched('task-deleted', taskId: $task->id);
+
+    expect(Task::find($task->id))->toBeNull();
+    expect(Comment::find($comment->id))->toBeNull();
+    expect(ChecklistItem::find($checklistItem->id))->toBeNull();
+    expect($tag->fresh())->not->toBeNull();
+});
+
+it('prevents non-authorized users from deleting tasks', function () {
+    $user1 = User::factory()->has(Team::factory())->create();
+    $team1 = $user1->teams()->first();
+    $project = $team1->projects()->create(['name' => 'Test Project', 'handle' => 'test-project']);
+    $task = $project->tasks()->create([
+        'title' => 'Test Task',
+        'user_id' => $user1->id,
+        'team_id' => $team1->id,
+        'number' => 1,
+    ]);
+
+    $user2 = User::factory()->create();
+
+    Livewire::actingAs($user2)->test('columns.pending', ['project' => $project])
+        ->call('deleteTask', $task->id)
+        ->assertForbidden();
+
+    expect(Task::find($task->id))->not->toBeNull();
 });

--- a/resources/views/components/columns/⚡section.blade.php
+++ b/resources/views/components/columns/⚡section.blade.php
@@ -18,6 +18,7 @@ new class extends Component
 
     #[On('task.moved')]
     #[On('task.updated')]
+    #[On('task-deleted')]
     public function refreshTasks()
     {
         unset($this->tasks);
@@ -118,6 +119,17 @@ new class extends Component
 
         $this->dispatch('task.moved');
     }
+
+    public function deleteTask($taskId)
+    {
+        $task = $this->section->project->tasks()->findOrFail($taskId);
+
+        $this->authorize('delete', $task->project);
+
+        $task->delete();
+
+        $this->dispatch('task-deleted', taskId: $task->id);
+    }
 };
 ?>
 
@@ -153,6 +165,30 @@ new class extends Component
                                 class="w-full max-w-[95vw] lg:max-w-216"
                             >
                                 <livewire:task :task="$task" lazy />
+                            </flux:modal>
+
+                            <flux:modal :name="'delete-task-' . $task->id" class="min-w-[22rem]">
+                                <div class="space-y-6">
+                                    <div>
+                                        <flux:heading size="lg">Delete task?</flux:heading>
+                                        <flux:text class="mt-2">
+                                            You're about to delete this task. This action cannot be reversed.
+                                        </flux:text>
+                                    </div>
+                                    <div class="flex gap-2">
+                                        <flux:spacer />
+                                        <flux:modal.close>
+                                            <flux:button variant="ghost">Cancel</flux:button>
+                                        </flux:modal.close>
+                                        <flux:button
+                                            type="submit"
+                                            variant="danger"
+                                            wire:click="deleteTask({{ $task->id }})"
+                                        >
+                                            Delete task
+                                        </flux:button>
+                                    </div>
+                                </div>
                             </flux:modal>
                         </div>
                     @empty

--- a/resources/views/components/columns/⚡section.test.php
+++ b/resources/views/components/columns/⚡section.test.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Models\ChecklistItem;
+use App\Models\Comment;
 use App\Models\Project;
 use App\Models\Section;
 use App\Models\Task;
@@ -253,4 +255,62 @@ it('moves multiple tasks to pending when section is deleted', function () {
         expect($task->section_moved_at)->toBeNull();
         expect($task->section_moved_by)->toBeNull();
     }
+});
+
+it('deletes task and all related resources successfully', function () {
+    $user = User::factory()->create();
+    $team = Team::factory()->create(['user_id' => $user->id]);
+    $project = Project::factory()->create(['team_id' => $team->id]);
+    $section = Section::factory()->create(['project_id' => $project->id]);
+    $task = Task::factory()->create([
+        'project_id' => $project->id,
+        'section_id' => $section->id,
+    ]);
+
+    $comment = $task->comments()->create([
+        'user_id' => $user->id,
+        'content' => 'Test comment',
+    ]);
+
+    $checklistItem = $task->checklistItems()->create([
+        'content' => 'Test checklist item',
+        'completed' => false,
+    ]);
+
+    $tag = $team->tags()->create(['name' => 'Bug Fix']);
+    $task->tags()->attach($tag->id);
+
+    expect($task->comments)->toHaveCount(1);
+    expect($task->checklistItems)->toHaveCount(1);
+    expect($task->tags)->toHaveCount(1);
+
+    Livewire::actingAs($user)
+        ->test('columns.section', ['section' => $section])
+        ->call('deleteTask', $task->id)
+        ->assertDispatched('task-deleted', taskId: $task->id);
+
+    expect(Task::find($task->id))->toBeNull();
+    expect(Comment::find($comment->id))->toBeNull();
+    expect(ChecklistItem::find($checklistItem->id))->toBeNull();
+    expect($tag->fresh())->not->toBeNull();
+});
+
+it('prevents non-authorized users from deleting tasks', function () {
+    $owner = User::factory()->create();
+    $team = Team::factory()->create(['user_id' => $owner->id]);
+    $project = Project::factory()->create(['team_id' => $team->id]);
+    $section = Section::factory()->create(['project_id' => $project->id]);
+    $task = Task::factory()->create([
+        'project_id' => $project->id,
+        'section_id' => $section->id,
+    ]);
+
+    $nonMember = User::factory()->create();
+
+    Livewire::actingAs($nonMember)
+        ->test('columns.section', ['section' => $section])
+        ->call('deleteTask', $task->id)
+        ->assertForbidden();
+
+    expect(Task::find($task->id))->not->toBeNull();
 });

--- a/resources/views/components/⚡task.blade.php
+++ b/resources/views/components/⚡task.blade.php
@@ -83,15 +83,6 @@ new class extends Component
         $this->dispatch('task.moved');
     }
 
-    public function deleteTask()
-    {
-        $this->authorize('delete', $this->task->project);
-
-        $this->task->delete();
-
-        $this->dispatch('task-deleted', taskId: $this->task->id);
-    }
-
     public function saveTitle()
     {
         $this->validate([
@@ -873,24 +864,6 @@ new class extends Component
             <flux:modal.trigger :name="'delete-task-' . $task->id">
                 <flux:button size="xs" variant="subtle" icon="trash">Delete task</flux:button>
             </flux:modal.trigger>
-
-            <flux:modal :name="'delete-task-' . $task->id" class="min-w-[22rem]">
-                <div class="space-y-6">
-                    <div>
-                        <flux:heading size="lg">Delete task?</flux:heading>
-                        <flux:text class="mt-2">
-                            You're about to delete this task. This action cannot be reversed.
-                        </flux:text>
-                    </div>
-                    <div class="flex gap-2">
-                        <flux:spacer />
-                        <flux:modal.close>
-                            <flux:button variant="ghost">Cancel</flux:button>
-                        </flux:modal.close>
-                        <flux:button type="submit" variant="danger" wire:click="deleteTask">Delete task</flux:button>
-                    </div>
-                </div>
-            </flux:modal>
         </div>
     </div>
 </div>

--- a/resources/views/components/⚡task.test.php
+++ b/resources/views/components/⚡task.test.php
@@ -1,8 +1,5 @@
 <?php
 
-use App\Models\ChecklistItem;
-use App\Models\Comment;
-use App\Models\Task;
 use App\Models\Team;
 use App\Models\User;
 use Illuminate\Http\UploadedFile;
@@ -715,68 +712,6 @@ it('can remove all assignees from task', function () {
 
     $task->refresh();
     expect($task->assignees)->toHaveCount(0);
-});
-
-it('deletes task and all related resources successfully', function () {
-    $user = User::factory()->has(Team::factory())->create();
-    $team = $user->teams()->first();
-    $project = $team->projects()->create(['name' => 'Test Project', 'handle' => 'test-project']);
-    $task = $project->tasks()->create([
-        'title' => 'Test Task',
-        'user_id' => $user->id,
-        'team_id' => $team->id,
-        'number' => 1,
-    ]);
-
-    // Create related resources
-    $comment = $task->comments()->create([
-        'user_id' => $user->id,
-        'content' => 'Test comment',
-    ]);
-
-    $checklistItem = $task->checklistItems()->create([
-        'content' => 'Test checklist item',
-        'completed' => false,
-    ]);
-
-    $tag = $team->tags()->create(['name' => 'Bug Fix']);
-    $task->tags()->attach($tag->id);
-
-    // Verify all related resources exist
-    expect($task->comments)->toHaveCount(1);
-    expect($task->checklistItems)->toHaveCount(1);
-    expect($task->tags)->toHaveCount(1);
-
-    $livewire = Livewire::actingAs($user)->test('task', ['task' => $task])
-        ->call('deleteTask')
-        ->assertDispatched('task-deleted', taskId: $task->id);
-
-    // Verify task and all related resources are deleted
-    expect(Task::find($task->id))->toBeNull();
-    expect(Comment::find($comment->id))->toBeNull();
-    expect(ChecklistItem::find($checklistItem->id))->toBeNull();
-    expect($tag->fresh())->not->toBeNull(); // Tag should still exist
-});
-
-it('prevents non-authorized users from deleting tasks', function () {
-    $user1 = User::factory()->has(Team::factory())->create();
-    $team1 = $user1->teams()->first();
-    $project = $team1->projects()->create(['name' => 'Test Project', 'handle' => 'test-project']);
-    $task = $project->tasks()->create([
-        'title' => 'Test Task',
-        'user_id' => $user1->id,
-        'team_id' => $team1->id,
-        'number' => 1,
-    ]);
-
-    $user2 = User::factory()->create();
-
-    Livewire::actingAs($user2)->test('task', ['task' => $task])
-        ->call('deleteTask')
-        ->assertForbidden();
-
-    // Verify task still exists
-    expect(Task::find($task->id))->not->toBeNull();
 });
 
 it('subscribes to task successfully', function () {


### PR DESCRIPTION
## Summary
- Moved delete task action from individual task component to each column component (pending, completed, closed, section)
- Delete modal is now rendered at the column level instead of in the task detail view
- Added `task-deleted` event listener to all columns to refresh task lists after deletion
- Updated all related tests to test deletion through column components

## Why
Moving delete task logic to column components maintains proper component hierarchy where deletion actions belong at the kanban board level rather than within individual task components.